### PR TITLE
[新增]reset css, guide style

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,15 @@
+import 'bootstrap/dist/css/bootstrap-grid.min.css';
+import './reset.css'
 import './App.scss';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { AdminMainPage, AdminPage, AdminUserPage, LoginPage, MainPage, RegisterPage, SettingPage, UserPage, DemoPage, BasePage, AdminBasePage } from 'pages';
+import { AdminMainPage, AdminPage, AdminUserPage, LoginPage, MainPage, RegisterPage, SettingPage, UserPage, DemoPage, BasePage, AdminBasePage, StyleGuidePage } from 'pages';
 import { UserPageLikeList, UserPageFollowingList, UserPageReplyList, UserPageFollowerList, UserPageTweet} from 'components';
-import 'bootstrap/dist/css/bootstrap-grid.min.css';
 
 function App() {
   const basename = process.env.PUBLIC_URL;
 
   return (
-    <div className="App">
+    <div>
       <BrowserRouter basename={basename}>
         <Routes>
           {/* 前台 */}
@@ -46,6 +47,7 @@ function App() {
 
           {/* Demo */}
           <Route path='demo' element={<DemoPage />} />
+          <Route path='style_guide' element={<StyleGuidePage />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,38 +1,137 @@
-.App {
-  text-align: center;
+:root {
+  --main: #FF6600;
+  --primary: #0062ff;
+  --secondary: #6C757D;
+  --success: #3DD598;
+  --warning: #FFC542;
+  --error: #FC5A5A;
+  --secondary-orange: #FF974A;
+  --secondary-blue: #50B5FF;
+  --secondary-green: #82C43C;
+  --secondary-purple: #A461D8;
+  --secondary-pink: #FF9AD5;
+  --dark-0: #FFFFFF;
+  --dark-20: #FAFAFB;
+  --dark-30: #F1F1F5;
+  --dark-40: #E2E2EA;
+  --dark-50: #D5D5DC;
+  --dark-60: #B5B5BE;
+  --dark-70: #92929D;
+  --dark-80: #696974;
+  --dark-90: #44444F;
+  --dark-100: #171725;
+
+  --gray-0: #F5F8FA;
+  --gray-20: #E6ECF0;
+  --gray-100: #657786;
+
+  --fz-regular: 1.6rem;
+  --fz-secondary: 1.4rem;
+  --fz-small: 1.2rem;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+$colors: (
+  "main": #FF6600,
+  "primary": #0062ff,
+  "secondary": #6C757D,
+  "success": #3DD598,
+  "warning": #FFC542,
+  "error": #FC5A5A,
+  "secondary-orange": #FF974A,
+  "secondary-blue": #50B5FF,
+  "secondary-green": #82C43C,
+  "secondary-purple": #A461D8,
+  "secondary-pink": #FF9AD5,
+  "dark-0": #FFFFFF,
+  "dark-20": #FAFAFB,
+  "dark-30": #F1F1F5,
+  "dark-40": #E2E2EA,
+  "dark-50": #D5D5DC,
+  "dark-60": #B5B5BE,
+  "dark-70": #92929D,
+  "dark-80": #696974,
+  "dark-90": #44444F,
+  "dark-100": #171725,
+  "gray-0": #F5F8FA,
+  "gray-20": #E6ECF0,
+  "gray-100": #657786,
+);
+
+$text-fzs: (
+  "regular": 1.6rem,
+  "secondary": 1.4rem,
+  "small": 1.2rem,
+);
+
+*,
+::after,
+::before {
+  box-sizing: border-box;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
+html {
+  font-size: 10px;
+}
+body {
+  font-family: 'Noto Sans TC', 'Montserrat', sans-serif !important;
+  font-weight: 400;
+  font-size: 1.6rem;
+  line-height: 2.6rem;
+  color: map-get($colors, "dark-100");
+}
+
+h1,h2,h3,h4,h5 {
+  font-weight: 700;
+}
+h1 {
+  font-size: 6.8rem;
+  line-height: 7.8rem;
+}
+h2 {
+  font-size: 4.2rem;
+  line-height: 5.2rem;
+}
+h3 {
+  font-size: 2.8rem;
+  line-height: 2.6rem;
+}
+h4 {
+  font-size: 2.4rem;
+  line-height: 2.6rem;
+}
+h5 {
+  font-size: 1.8rem;
+  line-height: 2.6rem;
+}
+p {
+  font-size: 1.6rem;
+  line-height: 2.6rem;
+  letter-spacing: 0.05rem;
+}
+small {
+  font-size: 1.2rem;
+  line-height: 2rem;
+}
+
+// font-weight
+.fw-bold {
+  font-weight: 700;
+}
+
+@each $name, $text-fz in $text-fzs {
+  // .text-fz-regular, text-fz-secondary
+  .text-fz-#{$name} {
+    font-size: $text-fz !important;
   }
 }
 
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
+@each $name, $color in $colors {
+  // .color-main, color-secondary
+  .color-#{$name} {
+    color: $color !important;
   }
-  to {
-    transform: rotate(360deg);
+  // .bgc-main, bgc-secondary
+  .bgc-#{$name} {
+    background-color: $color !important;
   }
 }

--- a/src/pages/StyleGuidePage.jsx
+++ b/src/pages/StyleGuidePage.jsx
@@ -1,0 +1,181 @@
+import styled from "styled-components";
+
+const StyledColorPanel = styled.div`
+  padding: 24px 32px;
+  border-radius: 30px;
+  &.big {
+    min-height: 200px;
+  }
+`;
+
+/**
+ * [Demo] Style guide
+ * 參見：https://www.figma.com/file/HUYe5neomwAMyHP8yXoa6w/Capstone%3A-Twitter_2022?node-id=34210-2436&t=har9QFzPkRy6Q7ox-0
+ * @returns 
+ */
+const StyleGuidePage = () => {
+  return (
+    <div className="container my-5">
+      <div className="row">
+        <div className="col-6 mb-3">
+          <h1 className="mb-5">h1. Bold / 68px</h1>
+          <h2 className="mb-5">h2. Bold / 42px</h2>
+          <h3 className="mb-5">h3. Medium / 28px</h3>
+          <h4 className="mb-5">h4. Medium / 24px</h4>
+          <h5 className="mb-5">h5. Medium / 18px</h5>
+        </div>
+        <div className="col-6 mb-3">
+          <p>基本文字大小：16px</p>
+          <p className="fw-bold mb-3">基本文字粗體：16px</p>
+
+          <p className="text-fz-secondary">次要文字大小：14px</p>
+          <p className="text-fz-secondary fw-bold mb-3">次要文字粗體：14px</p>
+
+          <small>最小文字：12px</small><br />
+          <small className="fw-bold mb-5">最小文字粗體：12px</small>
+        </div>
+        <div className="col-12">
+          <h2 className="mb-3">主色</h2>
+          <div className="row">
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="big bgc-main">
+                <h4 className="color-dark-0 mb-2">main</h4>
+                <p className="color-dark-0">#FF6600</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="big bgc-primary">
+                <h4 className="color-dark-0 mb-2">primary</h4>
+                <p className="color-dark-0">#0062ff</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="big bgc-secondary">
+                <h4 className="color-dark-0 mb-2">secondary</h4>
+                <p className="color-dark-0">#6C757D</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="big bgc-success">
+                <h4 className="color-dark-0 mb-2">success</h4>
+                <p className="color-dark-0">#3DD598</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="big bgc-warning">
+                <h4 className="color-dark-0 mb-2">warning</h4>
+                <p className="color-dark-0">#FFC542</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="big bgc-error">
+                <h4 className="color-dark-0 mb-2">error</h4>
+                <p className="color-dark-0">#FC5A5A</p>
+              </StyledColorPanel>
+            </div>
+          </div>
+
+          <h2 className="mt-5 mb-3">輔助色</h2>
+          <div className="row">
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-secondary-orange">
+                <h5 className="color-dark-0 mb-2">secondary-<br />orange</h5>
+                <p className="color-dark-0">#FF974A</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-secondary-blue">
+                <h5 className="color-dark-0 mb-2">secondary-<br />blue</h5>
+                <p className="color-dark-0">#50B5FF</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-secondary-green">
+                <h5 className="color-dark-0 mb-2">secondary-<br />green</h5>
+                <p className="color-dark-0">#82C43C</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-secondary-purple">
+                <h5 className="color-dark-0 mb-2">secondary-<br />purple</h5>
+                <p className="color-dark-0">#A461D8</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-secondary-pink">
+                <h5 className="color-dark-0 mb-2">secondary-<br />pink</h5>
+                <p className="color-dark-0">#FF9AD5</p>
+              </StyledColorPanel>
+            </div>
+          </div>
+
+          <h2 className="mt-5 mb-3">灰階色</h2>
+          <div className="row">
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-dark-100">
+                <h5 className="color-dark-0 mb-2">dark-100</h5>
+                <p className="color-dark-0">#171725</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-dark-90">
+                <h5 className="color-dark-0 mb-2">dark-90</h5>
+                <p className="color-dark-0">#44444F</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-dark-80">
+                <h5 className="color-dark-0 mb-2">dark-80</h5>
+                <p className="color-dark-0">#696974</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-dark-70">
+                <h5 className="color-dark-0 mb-2">dark-70</h5>
+                <p className="color-dark-0">#92929D</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-dark-60">
+                <h5 className="color-dark-0 mb-2">dark-60</h5>
+                <p className="color-dark-0">#B5B5BE</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-dark-50">
+                <h5 className="color-dark-70 mb-2">dark-50</h5>
+                <p className="color-dark-70">#D5D5DC</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-dark-40">
+                <h5 className="color-dark-70 mb-2">dark-40</h5>
+                <p className="color-dark-70">#E2E2EA</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-dark-30">
+                <h5 className="color-dark-70 mb-2">dark-30</h5>
+                <p className="color-dark-70">#F1F1F5</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-dark-20">
+                <h5 className="color-dark-70 mb-2">dark-20</h5>
+                <p className="color-dark-70">#FAFAFB</p>
+              </StyledColorPanel>
+            </div>
+            <div className="col-2 px-2 py-2">
+              <StyledColorPanel className="bgc-dark-0">
+                <h5 className="color-dark-70 mb-2">dark-0</h5>
+                <p className="color-dark-70">#FFFFFF</p>
+              </StyledColorPanel>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default StyleGuidePage;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,6 +9,7 @@ import UserPage from "./UserPage"
 import DemoPage from "./DemoPage"
 import BasePage from "./BasePage"
 import AdminBasePage from "./AdminBasePage"
+import StyleGuidePage from "./StyleGuidePage"
 
 export {
     AdminMainPage,
@@ -21,5 +22,6 @@ export {
     UserPage,
     DemoPage,
     BasePage,
-    AdminBasePage
+    AdminBasePage,
+    StyleGuidePage
 }

--- a/src/reset.css
+++ b/src/reset.css
@@ -1,0 +1,51 @@
+/* START - CSS reset
+   http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+/**
+ * CLOSE - CSS reset
+ */


### PR DESCRIPTION
- `reset.css`：rest 一些基本樣式。
- `StyleGuidePage.jsx` ：集中處理把顏色參數、字體大小、共用 class name ……等 ，參照 [figma 的 style guide 規範](https://www.figma.com/file/HUYe5neomwAMyHP8yXoa6w/Capstone%3A-Twitter_2022?node-id=34212-1928&t=har9QFzPkRy6Q7ox-0)，路徑輸入 `/style_guide` 看到樣式套用的 demo。