### PR TITLE
[切版]_BasePage.jsx 和 AdminBasePage [修改]_前台登入和後台登入分別呼叫不同 API

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,12 +1,17 @@
 import axios from "axios";
 import { baseUrl } from "./base";
 
-export const login = async ({ account, password, role }) => {
+/**
+ * [使用者] 登入 API
+ * @param {string} account - 帳號
+ * @param {string} password - 密碼
+ * @returns 
+ */
+export const userLogin = async ({ account, password}) => {
   try {
-    const response = await axios.post(`${baseUrl}/api/signin`,{
+    const response = await axios.post(`${baseUrl}/api/users/signin`,{
       account,
-      password,
-      role
+      password
     })
     return response.data
 
@@ -15,6 +20,15 @@ export const login = async ({ account, password, role }) => {
   }
 }
 
+/**
+ * [使用者] 註冊 API
+ * @param {string} name - 名稱
+ * @param {string} account - 帳號
+ * @param {string} email - email
+ * @param {string} password - 密碼
+ * @param {string} checkPassword - 再次確認密碼
+ * @returns 
+ */
 export const register = async ({ name, account, email, password, checkPassword }) => {
   try {
     const response = await axios.post(`${baseUrl}/api/users`,{
@@ -23,6 +37,25 @@ export const register = async ({ name, account, email, password, checkPassword }
       email,
       password,
       checkPassword
+    })
+    return response.data
+
+  } catch (error) {
+    return error.response.data
+  }
+}
+
+/**
+ * [管理者] 登入 API
+ * @param {string} account - 帳號
+ * @param {string} password - 密碼
+ * @returns 
+ */
+export const adminLogin = async ({ account, password}) => {
+  try {
+    const response = await axios.post(`${baseUrl}/api/admin/signin`,{
+      account,
+      password
     })
     return response.data
 

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -5,7 +5,7 @@ import { LogOutIcon } from "assets/images"
 const StyledSideBarContainer = styled.div`
     position: relative;
     padding-bottom: 62px;
-    min-height: 100vh;
+    min-height: calc(100vh - 32px);
     max-width: 178px;
 `
 
@@ -68,10 +68,8 @@ const StyledIconContainer = styled.span`
 const SideBar = ({ children, logOutButtonOnClick }) => {
     return (
         <StyledSideBarContainer>
-            <ACLogo className="mt-2"/>
-            
+            <ACLogo/>
             { children }
-
             <StyledLogOutButtonContainer>
                 <StyledLogOutButton
                     type="button"

--- a/src/pages/AdminBasePage.jsx
+++ b/src/pages/AdminBasePage.jsx
@@ -2,6 +2,47 @@ import { useEffect } from "react"
 import { Outlet, useNavigate } from "react-router-dom"
 import { SideBar, SideBarList, SideBarItem } from "components"
 import { useAuth } from "contexts/AuthContext"
+import styled from "styled-components"
+
+const StyledContainer = styled.div`
+  width: 100%;
+  max-width: 100%;
+  @media screen and (min-width: 992px) {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 960px;
+  }
+  @media screen and (min-width: 1200px) {
+    max-width: 1140px;
+  }
+`
+
+const StyledWrap = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+`
+
+const StyledStickyContainer = styled.div`
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0px;
+`
+
+const StyledSideBarContainer = styled.div`
+  position: relative;
+  width: 100%;
+  max-width: 178px;
+`
+
+const StyledMain = styled.div`
+  position: relative;
+  border-left: 1px solid var(--gray-20);
+  min-height: 200vh;
+  width: 100%;
+  max-width: calc(100% - 202px);
+`
+
 /**
  * [後台] 放置後台所有頁面（不包含後台登入頁） 共用 Component
  * @returns 
@@ -34,23 +75,27 @@ const AdminBasePage = () => {
   }
 
   return (
-    <div className="container">
-      <div className="row">
-        <div className="col-3">
-          <SideBar
-            logOutButtonOnClick={handleLogOut}
-          >
-            <SideBarList>
-              <SideBarItem to="/admin_main" text="推文清單" icon="home" />
-              <SideBarItem to="/admin_users" text="使用者列表" icon="user" />
-            </SideBarList>
-          </SideBar>
-        </div>
-        <div className="col-6">
+    <StyledContainer>
+      <StyledWrap>
+        <StyledSideBarContainer>
+          <StyledStickyContainer>
+            <SideBar
+              logOutButtonOnClick={handleLogOut}
+            >
+              <SideBarList>
+                <SideBarItem to="/admin_main" text="推文清單" icon="home" />
+                <SideBarItem to="/admin_users" text="使用者列表" icon="user" />
+              </SideBarList>
+            </SideBar>
+          </StyledStickyContainer>
+        </StyledSideBarContainer>
+
+        <StyledMain>
           <Outlet />
-        </div>
-      </div>
-    </div>
+        </StyledMain>
+
+      </StyledWrap>
+    </StyledContainer>
   )
 }
 

--- a/src/pages/AdminBasePage.jsx
+++ b/src/pages/AdminBasePage.jsx
@@ -26,7 +26,7 @@ const StyledWrap = styled.div`
 const StyledStickyContainer = styled.div`
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
+  top: 16px;
 `
 
 const StyledSideBarContainer = styled.div`

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -20,7 +20,7 @@ const AdminPage = () => {
     const [account, setAccount] = useState('')
     const [password, setPassword] = useState('')
     const [disabledSubmitBtn, setDisabledSubmitBtn] = useState(false)
-    const { hasToken, login, currentRegistrant} = useAuth()
+    const { hasToken, adminLogin, currentRegistrant} = useAuth()
     let navigate = useNavigate()
 
     // 檢查是否有 token
@@ -53,12 +53,10 @@ const AdminPage = () => {
         }
 
         // 呼叫登入 API
-        const response = await login({
+        const response = await adminLogin({
             account,
-            password,
-            role: 'admin'
+            password
         })
-        console.log(response)
 
         // 檢查是否登入成功
         const isLogin = (response.status === 'success') ? true : false

--- a/src/pages/BasePage.jsx
+++ b/src/pages/BasePage.jsx
@@ -1,8 +1,60 @@
 import { Outlet, useNavigate } from "react-router-dom"
-import { PopularList, SideBar, SideBarList, SideBarItem, Button } from "../components"
-import { useEffect } from "react"
+import { PopularList, SideBar, SideBarList, SideBarItem, Button, TweetModal } from "../components"
+import { useEffect, useState } from "react"
+import { createPortal } from "react-dom";
 import { useAuth } from "contexts/AuthContext"
+import styled from "styled-components"
 import { dummyUsers } from "../testData/dummyRecommendUser";
+
+const StyledContainer = styled.div`
+  width: 100%;
+  max-width: 100%;
+  @media screen and (min-width: 992px) {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 960px;
+  }
+  @media screen and (min-width: 1200px) {
+    max-width: 1140px;
+  }
+`
+
+const StyledWrap = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+`
+
+const StyledStickyContainer = styled.div`
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0px;
+`
+
+const StyledSideBarContainer = styled.div`
+  position: relative;
+  width: 100%;
+  max-width: 178px;
+`
+
+const StyledPopularListContainer = styled.div`
+  position: relative;
+  width: 100%;
+  max-width: calc(100% - 866px);
+
+  > ${StyledStickyContainer} {
+    top: 16px;
+  }
+`
+
+const StyledMain = styled.div`
+  position: relative;
+  border-left: 1px solid var(--gray-20);
+  border-right: 1px solid var(--gray-20);
+  min-height: 200vh;
+  width: 100%;
+  max-width: 640px;
+`
 
 /**
  * [前台] 放置前台所有頁面（不包含前台登入頁、註冊頁）共用 Component
@@ -11,6 +63,7 @@ import { dummyUsers } from "../testData/dummyRecommendUser";
  */
 const BasePage = ({showPopularList = true}) => {
   const { hasToken, currentRegistrant, logout } = useAuth()
+  const [showTweetModal, setShowTweetModal] = useState(false)
   let navigate = useNavigate()
 
   // 檢查是否有 token
@@ -36,31 +89,48 @@ const BasePage = ({showPopularList = true}) => {
   }
 
   return (
-    <div className="container">
-      <div className="row">
-        <div className="col-3">
-          <SideBar
-            logOutButtonOnClick={handleLogOut}
-          >
-            <SideBarList>
-              <SideBarItem to="/main" text="首頁" icon="home" />
-              <SideBarItem to={`/user/${currentRegistrant.id}`} text="個人資料" icon="user" />
-              <SideBarItem to="/setting" text="設定" icon="setting" />
-            </SideBarList>
-            <Button
-              display="block" 
-              text="推文"
-            />
-          </SideBar>
-        </div>
-        <div className="col-6">
+    <StyledContainer>
+      <StyledWrap>
+
+        <StyledSideBarContainer>
+          <StyledStickyContainer>
+            <SideBar
+              logOutButtonOnClick={handleLogOut}
+            >
+              <SideBarList>
+                <SideBarItem to="/main" text="首頁" icon="home" />
+                <SideBarItem to={`/user/${currentRegistrant.id}`} text="個人資料" icon="user" />
+                <SideBarItem to="/setting" text="設定" icon="setting" />
+              </SideBarList>
+              <Button
+                display="block" 
+                text="推文"
+                onClick={()=>{
+                  setShowTweetModal(true)
+                }}
+              />
+            </SideBar>
+          </StyledStickyContainer>
+          
+        </StyledSideBarContainer>
+
+        <StyledMain>
           <Outlet />
-        </div>
-        <div className="col-3">
-          { showPopularList && <PopularList recommendUsers={dummyUsers} /> }
-        </div>
-      </div>
-    </div>
+        </StyledMain>
+
+        <StyledPopularListContainer>
+          <StyledStickyContainer>
+            { showPopularList && <PopularList recommendUsers={dummyUsers} /> }
+          </StyledStickyContainer>
+        </StyledPopularListContainer>
+
+      </StyledWrap>
+
+      {showTweetModal && createPortal(
+        <TweetModal onClose={() => setShowTweetModal(false)}/>,
+        document.body
+      )}
+    </StyledContainer>
   );
 }
 

--- a/src/pages/BasePage.jsx
+++ b/src/pages/BasePage.jsx
@@ -28,7 +28,7 @@ const StyledWrap = styled.div`
 const StyledStickyContainer = styled.div`
   position: -webkit-sticky;
   position: sticky;
-  top: 0px;
+  top: 16px;
 `
 
 const StyledSideBarContainer = styled.div`
@@ -41,10 +41,6 @@ const StyledPopularListContainer = styled.div`
   position: relative;
   width: 100%;
   max-width: calc(100% - 866px);
-
-  > ${StyledStickyContainer} {
-    top: 16px;
-  }
 `
 
 const StyledMain = styled.div`

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -20,7 +20,7 @@ const LoginPage = () => {
     const [account, setAccount] = useState('')
     const [password, setPassword] = useState('')
     const [disabledSubmitBtn, setDisabledSubmitBtn] = useState(false)
-    const { hasToken, login, currentRegistrant } = useAuth()
+    const { hasToken, userLogin, currentRegistrant } = useAuth()
     let navigate = useNavigate()
 
     // 檢查是否有 token
@@ -53,10 +53,9 @@ const LoginPage = () => {
         }
 
         // 呼叫登入 API
-        const response = await login({
+        const response = await userLogin({
             account,
-            password,
-            role: 'user'
+            password
         })
 
         // 檢查是否登入成功

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -57,7 +57,6 @@ const RegisterPage = () => {
             password,
             checkPassword
         })
-        console.log(response)
 
         const isRegister = (response.status === 'success') ? true : false
         if (isRegister) {


### PR DESCRIPTION
**[切版]_`BasePage.jsx` 和 `AdminBasePage`**
要符合 [figma](https://www.figma.com/file/HUYe5neomwAMyHP8yXoa6w/Capstone%3A-Twitter_2022?node-id=34234-2029&t=gTodwVCQ2rQeRmtB-0) 規範樣式，側邊選單和推薦跟隨當卷軸滾動時固定在畫面上。

**[調整]**
前後台登入分別呼叫不同 API。
管理者帳號不可登入前台，若嘗試登入等同於「帳號不存在」。
一般使用者帳號不可登入後台，若嘗試登入等同於「帳號不存在」。