### PR TITLE
[切版]_前台使用者回覆列表頁

### DIFF
--- a/src/components/UserPageReplyList.jsx
+++ b/src/components/UserPageReplyList.jsx
@@ -1,12 +1,15 @@
 import { useParams } from "react-router-dom"
-import { UserHeader, TabList, TabItem, ReplyList } from "components"
+import { UserHeader, TabList, TabItem, ReplyList, UserProfile } from "components"
 //測試假資料
 import { dummyUserRepliedTweets } from "../testData/dummyUserRepliedTweets";
+import { dummyUserProfile } from "testData/dummyUserProfile";
+
 /**
  * [前台] 使用者資料頁（回復）
  * @returns 
  */
 const UserPageReplyList = () => {
+    const userProfile = dummyUserProfile
     const { user_id } = useParams();
 
     return (
@@ -15,12 +18,20 @@ const UserPageReplyList = () => {
                 name="anna"
                 tweetCount={10}
             />
+            <UserProfile
+                name={userProfile.name}
+                account={userProfile.account}
+                description={userProfile.introduction}
+                backgroundImageUrl={userProfile.cover}
+                imageUrl={userProfile.avatar}
+                followingCount={userProfile.followingCount}
+                followerCount={userProfile.followerCount}
+            />
             <TabList>
                 <TabItem to={`/user/${user_id}`} text="推文" />
                 <TabItem to={`/user/${user_id}/reply`} text="回覆" />
                 <TabItem to={`/user/${user_id}/like`} text="喜歡的內容" />
             </TabList>
-            <p>UserPageReplyList.jsx</p>
             <ReplyList repliedList={dummyUserRepliedTweets}/>
         </>
     )


### PR DESCRIPTION
可以從 `/user/14/reply` 看到畫面。

[未調整]
`UserProfile` 編輯個人資料按鈕，挑出編輯彈跳視窗需要等 `UserEditModal` 完成才能執行。
使用者非登入者的情形下，UserProfile 不顯示編輯個人資料按鈕，待實作取得使用者資訊再執行。