### PR TITLE
[API 串接]_後台使用者列表列

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -3,9 +3,22 @@ import { axiosInstance, baseUrl } from "./base"
 export const getUsers = async () => {
   try {
     const response = await axiosInstance.get(`${baseUrl}/api/admin/users`);
-    return response.data
+    const data = {
+      status: response.status,
+      data: response.data
+    }
+
+    console.log(response)
+    return data
 
   } catch (error) {
-    return error.response.data
+    const response = error.response
+    const data = {
+      status: response.status,
+      data: response.data
+    }
+
+    console.error('[Get users failed] :', data)
+    return data
   }
 }

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1,0 +1,11 @@
+import { axiosInstance, baseUrl } from "./base"
+
+export const getUsers = async () => {
+  try {
+    const response = await axiosInstance.get(`${baseUrl}/api/admin/users`);
+    return response.data
+
+  } catch (error) {
+    return error.response.data
+  }
+}

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -19,7 +19,7 @@ axiosInstance.interceptors.request.use(
     return config;
   },
   (error) => {
-    return error
+    console.error(error)
   },
 );
 

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -1,3 +1,26 @@
+import axios from "axios"
+
 export const baseUrl = "https://safe-cliffs-81319.herokuapp.com"
 
+const axiosInstance = axios.create({
+  baseURL: baseUrl,
+});
 
+axiosInstance.interceptors.request.use(
+  (config) => {
+    // 從 localStorage 將 token 取出
+    const token = localStorage.getItem('token');
+
+    // 如果 token 存在的話，則帶入到 headers 當中
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    return config;
+  },
+  (error) => {
+    return error
+  },
+);
+
+export { axiosInstance }

--- a/src/components/AdminUserList.jsx
+++ b/src/components/AdminUserList.jsx
@@ -11,14 +11,18 @@ const StyledUserList = styled.div`
  * @returns 
  */
 const AdminUserList = ({ users }) => {
-    const UserList = users.map(user => {
-        return (
-            <AdminUserItem
-                key={user.id}
-                user={user}
-            />
-        )
-    })
+    let UserList = <></>
+
+    if (users.length > 0) {
+        UserList = users.map(user => {
+            return (
+                <AdminUserItem
+                    key={user.id}
+                    user={user}
+                />
+            )
+        })
+    }
 
     return (
         <StyledUserList className="my-3 px-3">

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -10,7 +10,7 @@ const defaultAuthContext = {
   adminLogin: null, // [管理者] 登入
   register: null, // [使用者] 註冊
   logout: null, // 登出
-  prevPath: null
+  prevPath: null // 上一頁路徑
 }
 const AuthContext = createContext(defaultAuthContext)
 
@@ -26,9 +26,9 @@ export const useAuth = () => useContext(AuthContext)
  * @returns 
  */
 export const AuthProvider = ({ children }) => {
-  const [hasToken, setHasToken] = useState(false)
+  const [hasToken, setHasToken] = useState(false) // 是否有 token
   const [payload, setPayload] = useState(null) // token 解析後 payload 帶的資訊
-  const [prevPath, setPrevPath] = useState('/main')
+  const [prevPath, setPrevPath] = useState('/main') // 上一頁路徑
   const { pathname } = useLocation()
 
   useEffect(() => {
@@ -44,9 +44,9 @@ export const AuthProvider = ({ children }) => {
       setPayload(tempPayload)
       
       // 紀錄上一頁路徑
-      const adminPaths = ['/admin_main', '/admin_users']
-      const landingPaths = ['/admin', '/login', '/register']
+      const landingPaths = ['/admin', '/login', '/register', '/']
       if (!(landingPaths.includes(pathname))) {
+        const adminPaths = ['/admin_main', '/admin_users']
         let prevPath = ''
         if (tempPayload.role === 'admin') {
           prevPath = adminPaths.includes(pathname) ? pathname : '/admin_main'
@@ -137,6 +137,7 @@ export const AuthProvider = ({ children }) => {
           setPayload(null)
           setHasToken(false)
         },
+        // 上一頁路徑
         prevPath
       }}
     >

--- a/src/pages/AdminBasePage.jsx
+++ b/src/pages/AdminBasePage.jsx
@@ -55,7 +55,7 @@ const AdminBasePage = () => {
   // 有 -> (管理者) 留在此頁； (使用者) 導到首頁
   useEffect(() => {
     if (!hasToken) {
-      navigate('/login');
+      navigate('/admin');
     } else if (hasToken && currentRegistrant.role !== 'admin') {
       navigate('/main');
     }

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -20,21 +20,15 @@ const AdminPage = () => {
     const [account, setAccount] = useState('')
     const [password, setPassword] = useState('')
     const [disabledSubmitBtn, setDisabledSubmitBtn] = useState(false)
-    const { hasToken, adminLogin, currentRegistrant} = useAuth()
+    const { hasToken, adminLogin, prevPath} = useAuth()
     let navigate = useNavigate()
 
     // 檢查是否有 token
-    // 有 -> (使用者) 導到首頁； (管理者) 導到後台推文清單
-    // 無 -> 停留在此頁
     useEffect(() => {
         if (hasToken) {
-            if (currentRegistrant.role === 'admin') {
-                navigate('/admin_main');
-            } else {
-                navigate('/main');
-            }
+            navigate(prevPath);
         }
-    }, [navigate, hasToken, currentRegistrant]);
+    }, [navigate, hasToken, prevPath]);
 
     // 阻止表單提交
     function handleSubmit(e) {

--- a/src/pages/AdminUserPage.jsx
+++ b/src/pages/AdminUserPage.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react"
 import { Header, AdminUserList } from "components"
 import { getUsers } from "api/admin"
+import { useAuth } from "contexts/AuthContext"
+import Swal from "sweetalert2"
 
 /**
  * [後台] 後台使用者列表頁
@@ -8,20 +10,34 @@ import { getUsers } from "api/admin"
  */
 const AdminUserPage = () => {
     const [users, setUsers] = useState([])
+    const { logout } = useAuth()
 
     useEffect(() => {
         const getUsersAsync = async () => {
             try {
-                const users = await getUsers()
-                setUsers(
-                    users.map((user) => {
+                const response = await getUsers()
+                const logoutStatus = [401, 403]
+                
+                // token 失效 -> 登出
+                if (logoutStatus.includes(response.status)) {
+                    Swal.fire({
+                        title: '請重新登入!',
+                        icon: 'warning',
+                        html: `<p>${response.data.message}</p>`,
+                        showConfirmButton: false,
+                        timer: 3000,
+                        position: 'top',
+                    });
+                    logout()
+
+                } else if (response.status === 200) {
+                    const users = response.data.map((user) => {
                         return {
                             ...user
                         }
                     })
-                )
-                
-                console.log(users);
+                    setUsers(users)
+                }
             } catch (error) {
                 console.error(error)
             }

--- a/src/pages/AdminUserPage.jsx
+++ b/src/pages/AdminUserPage.jsx
@@ -10,7 +10,22 @@ import Swal from "sweetalert2"
  */
 const AdminUserPage = () => {
     const [users, setUsers] = useState([])
+    const [logoutMsg, setLogoutMsg] = useState('')
     const { logout } = useAuth()
+
+    useEffect(() => {
+        if (logoutMsg.length > 0) {
+            Swal.fire({
+                title: '請重新登入!',
+                icon: 'info',
+                html: `<p>${logoutMsg}</p>`,
+                showConfirmButton: false,
+                timer: 3000,
+                position: 'top',
+            });
+            logout()
+        }
+    }, [logoutMsg, logout])
 
     useEffect(() => {
         const getUsersAsync = async () => {
@@ -18,17 +33,8 @@ const AdminUserPage = () => {
                 const response = await getUsers()
                 const logoutStatus = [401, 403]
                 
-                // token 失效 -> 登出
                 if (logoutStatus.includes(response.status)) {
-                    Swal.fire({
-                        title: '請重新登入!',
-                        icon: 'warning',
-                        html: `<p>${response.data.message}</p>`,
-                        showConfirmButton: false,
-                        timer: 3000,
-                        position: 'top',
-                    });
-                    logout()
+                    setLogoutMsg(response.data.message)
 
                 } else if (response.status === 200) {
                     const users = response.data.map((user) => {
@@ -44,7 +50,7 @@ const AdminUserPage = () => {
         }
 
         getUsersAsync()
-    }, [logout])
+    }, [])
 
     return (
         <>

--- a/src/pages/AdminUserPage.jsx
+++ b/src/pages/AdminUserPage.jsx
@@ -1,15 +1,39 @@
+import { useState, useEffect } from "react"
 import { Header, AdminUserList } from "components"
-import { dummyAdminUsers } from "testData/dummyAdminUsers"
+import { getUsers } from "api/admin"
 
 /**
  * [後台] 後台使用者列表頁
  * @returns 
  */
 const AdminUserPage = () => {
+    const [users, setUsers] = useState([])
+
+    useEffect(() => {
+        const getUsersAsync = async () => {
+            try {
+                const users = await getUsers()
+                setUsers(
+                    users.map((user) => {
+                        return {
+                            ...user
+                        }
+                    })
+                )
+                
+                console.log(users);
+            } catch (error) {
+                console.error(error)
+            }
+        }
+
+        getUsersAsync()
+    }, [])
+
     return (
         <>
             <Header text="使用者列表" />
-            <AdminUserList users={dummyAdminUsers}/>
+            <AdminUserList users={users}/>
         </>
     )
 }

--- a/src/pages/AdminUserPage.jsx
+++ b/src/pages/AdminUserPage.jsx
@@ -44,7 +44,7 @@ const AdminUserPage = () => {
         }
 
         getUsersAsync()
-    }, [])
+    }, [logout])
 
     return (
         <>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,11 +1,19 @@
 import { useEffect } from "react"
 import { useNavigate } from "react-router-dom"
+import { useAuth } from "contexts/AuthContext"
 
 const HomePage = () => {
-    const navigate = useNavigate()
-    useEffect(()=>{
-        navigate('/login')
-    },[navigate])
+    const { hasToken, prevPath } = useAuth()
+    let navigate = useNavigate()
+    
+    // 檢查是否有 token
+    useEffect(() => {
+        if (!hasToken) {
+            navigate('/login')
+        } else {
+            navigate(prevPath)
+        }
+    }, [navigate, hasToken, prevPath])
 }
 
 export default HomePage

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -20,7 +20,7 @@ const LoginPage = () => {
     const [account, setAccount] = useState('')
     const [password, setPassword] = useState('')
     const [disabledSubmitBtn, setDisabledSubmitBtn] = useState(false)
-    const { hasToken, userLogin, currentRegistrant, prevPath } = useAuth()
+    const { hasToken, userLogin, prevPath } = useAuth()
     let navigate = useNavigate()
     
     // 檢查是否有 token
@@ -28,7 +28,7 @@ const LoginPage = () => {
         if (hasToken) {
             navigate(prevPath);
         }
-    }, [navigate, hasToken, currentRegistrant, prevPath]);
+    }, [navigate, hasToken, prevPath]);
     
     // 阻止表單提交
     function handleSubmit(e) {

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -20,21 +20,15 @@ const LoginPage = () => {
     const [account, setAccount] = useState('')
     const [password, setPassword] = useState('')
     const [disabledSubmitBtn, setDisabledSubmitBtn] = useState(false)
-    const { hasToken, userLogin, currentRegistrant } = useAuth()
+    const { hasToken, userLogin, currentRegistrant, prevPath } = useAuth()
     let navigate = useNavigate()
-
+    
     // 檢查是否有 token
-    // 有 -> (使用者) 導到首頁； (管理者) 導到後台推文清單
-    // 無 -> 停留在此頁
     useEffect(() => {
         if (hasToken) {
-            if (currentRegistrant.role === 'admin') {
-                navigate('/admin_main');
-            } else {
-                navigate('/main');
-            }
+            navigate(prevPath);
         }
-    }, [navigate, hasToken, currentRegistrant]);
+    }, [navigate, hasToken, currentRegistrant, prevPath]);
     
     // 阻止表單提交
     function handleSubmit(e) {


### PR DESCRIPTION
- 管理者可以瀏覽站內所有的使用者清單。
- 當呼叫取得使用者列表 API 回傳的 status 是 401, 403 讓管理者登出，進到進到 `/admin` (後台登入頁)。

**[修正]**
在不影響[原本登入/註冊](https://github.com/Ai-Chen-Hsieh/Twitter-2023/pull/19#issue-1640959011)功能下，修正
- 當後台 `/admin_main` (推文清單) 或 `/admin_users`(使用者列表) 登出後會進到 `/admin` (後台登入頁)。
- 本機開發當使用者登入時，進到前台的任一頁面，重整不會強制導到 `/main` (首頁)；當管理者登入時，進到後台的任一頁面，重整不會強制導到後台 `/admin_main` (推文清單)。
- `HomePage` 加上是否有 token 判斷，如果有則回上一頁 (不包含 `/`、`/admin`、`/login`、`/register`)，沒有則回首頁。