### PR TITLE
[後台] 管理者可以看到所有推文、可以刪除推文

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -22,3 +22,30 @@ export const getUsers = async () => {
     return data
   }
 }
+
+/**
+ * [後台] 取得推文清單
+ * @returns 
+ */
+export const getAdminTweets = async () => {
+  try {
+    const response = await axiosInstance.get(`${baseUrl}/api/admin/tweets`);
+    const data = {
+      status: response.status,
+      data: response.data
+    }
+
+    console.log(response)
+    return data
+
+  } catch (error) {
+    const response = error.response
+    const data = {
+      status: response.status,
+      data: response.data
+    }
+
+    console.error('[Get tweets failed] :', data)
+    return data
+  }
+}

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -36,7 +36,7 @@ export const getAdminTweets = async () => {
 
 export const deleteAdminTweet = async (tweedId) => {
   try {
-    const response = await axiosInstance.delete(`${baseUrl}/admin/tweets/${tweedId}`);
+    const response = await axiosInstance.delete(`${baseUrl}/api/admin/tweets/${tweedId}`);
     const data = getData(response)
     return data
 

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1,24 +1,18 @@
-import { axiosInstance, baseUrl } from "./base"
+import { axiosInstance, baseUrl, getData } from "./base"
 
+/**
+ * [後台] 取得使用者清單
+ * @returns 
+ */
 export const getUsers = async () => {
   try {
     const response = await axiosInstance.get(`${baseUrl}/api/admin/users`);
-    const data = {
-      status: response.status,
-      data: response.data
-    }
-
-    console.log(response)
+    const data = getData(response)
     return data
 
   } catch (error) {
     const response = error.response
-    const data = {
-      status: response.status,
-      data: response.data
-    }
-
-    console.error('[Get users failed] :', data)
+    const data = getData(response)
     return data
   }
 }
@@ -30,22 +24,25 @@ export const getUsers = async () => {
 export const getAdminTweets = async () => {
   try {
     const response = await axiosInstance.get(`${baseUrl}/api/admin/tweets`);
-    const data = {
-      status: response.status,
-      data: response.data
-    }
-
-    console.log(response)
+    const data = getData(response)
     return data
 
   } catch (error) {
     const response = error.response
-    const data = {
-      status: response.status,
-      data: response.data
-    }
+    const data = getData(response)
+    return data
+  }
+}
 
-    console.error('[Get tweets failed] :', data)
+export const deleteAdminTweet = async (tweedId) => {
+  try {
+    const response = await axiosInstance.delete(`${baseUrl}/admin/tweets/${tweedId}`);
+    const data = getData(response)
+    return data
+
+  } catch (error) {
+    const response = error.response
+    const data = getData(response)
     return data
   }
 }

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -2,6 +2,14 @@ import axios from "axios"
 
 export const baseUrl = "https://safe-cliffs-81319.herokuapp.com"
 
+export const getData = (response) => {
+  console.log(response)
+  return {
+    status: response.status,
+    data: response.data
+  }
+}
+
 const axiosInstance = axios.create({
   baseURL: baseUrl,
 });

--- a/src/components/AdminTweetItem.jsx
+++ b/src/components/AdminTweetItem.jsx
@@ -67,6 +67,13 @@ const StyledItemDeleteButton = styled.button`
  * @returns 
  */
 const AdminTweetItem = ({ item, onDelete }) => {
+    let description = item.description
+
+    // 可以直接在清單上快覽 Tweet 的前 50 個字 ?
+    if (description.length > 50) {
+        description = `${item.description.slice(0, 50)}...`
+    }
+
     return(
         <StyledItemContainer>
             <StyledItemAvatarContainer>
@@ -79,7 +86,7 @@ const AdminTweetItem = ({ item, onDelete }) => {
                         @{item.account}・{item.createdAt}
                     </span>
                 </header>
-                <p>{item.description}</p>
+                <p>{description}</p>
             </StyledItemInfosContainer>
 
             <StyledItemDeleteButton

--- a/src/components/AdminTweetList.jsx
+++ b/src/components/AdminTweetList.jsx
@@ -5,7 +5,7 @@ import AdminTweetItem from "./AdminTweetItem"
  * @param {array} tweetList - 推文清單 
  * @returns 
  */
-const AdminTweetList = ({ tweetList }) => {
+const AdminTweetList = ({ tweetList, onDelete }) => {
     let TweetItem = <></>
 
     if (tweetList.length > 0) {
@@ -14,6 +14,9 @@ const AdminTweetList = ({ tweetList }) => {
                 <AdminTweetItem
                     key={tweetItem.id}
                     item={tweetItem}
+                    onDelete={(id) => {
+                        onDelete?.(id)
+                    }}
                 />
             )
         })

--- a/src/components/AdminTweetList.jsx
+++ b/src/components/AdminTweetList.jsx
@@ -6,14 +6,18 @@ import AdminTweetItem from "./AdminTweetItem"
  * @returns 
  */
 const AdminTweetList = ({ tweetList }) => {
-    const TweetItem = tweetList.map(tweetItem => {
-        return (
-            <AdminTweetItem
-                key={tweetItem.id}
-                item={tweetItem}
-            />
-        )
-    })
+    let TweetItem = <></>
+
+    if (tweetList.length > 0) {
+        TweetItem = tweetList.map(tweetItem => {
+            return (
+                <AdminTweetItem
+                    key={tweetItem.id}
+                    item={tweetItem}
+                />
+            )
+        })
+    }
 
     return(
         <>

--- a/src/pages/AdminMainPage.jsx
+++ b/src/pages/AdminMainPage.jsx
@@ -19,7 +19,7 @@ const StyledContainer = styled.div`
  */
 const AdminMainPage = () => {
     const [tweets, setTweets] = useState([])
-    const [logoutMsg, setLogoutMsg] = useState({})
+    const [logoutMsg, setLogoutMsg] = useState('')
     const [deleteMsg, setDeleteMsg] = useState(null)
     const { logout } = useAuth()
 

--- a/src/pages/AdminMainPage.jsx
+++ b/src/pages/AdminMainPage.jsx
@@ -1,7 +1,7 @@
 import styled from "styled-components"
 import { useState, useEffect } from "react"
 import { useAuth } from "contexts/AuthContext"
-import { getAdminTweets } from "api/admin"
+import { getAdminTweets, deleteAdminTweet } from "api/admin"
 import { AdminTweetList, Header } from "components"
 import Swal from "sweetalert2"
 
@@ -60,11 +60,30 @@ const AdminMainPage = () => {
 
         getTweetsAsync()
     },[])
+    
+    // 刪除推文
+    async function handleDelete(id) {
+        try {
+            await deleteAdminTweet(id)
+            // const logoutStatus = [401, 403]
+                
+            // if (logoutStatus.includes(response.status)) {
+            //     setLogoutMsg(response.data.message)
+
+            // } 
+
+        } catch (error) {
+            console.log(error)
+        }
+    }
 
     return (
         <StyledContainer>
             <Header text="推文清單" />
-            <AdminTweetList tweetList={tweets} />
+            <AdminTweetList
+                tweetList={tweets}
+                onDelete={handleDelete}
+            />
         </StyledContainer>
     )
 }


### PR DESCRIPTION
**[後台] 推文清單頁面 `/admin_main`**
- 當呼叫取得使用者列表 API 回傳的 status 是 401, 403 讓管理者登出，進到進到 /admin (後台登入頁)。
- 管理者可以直接在清單上快覽 Tweet 的前 50 個字
- 管理者可以在清單上直接刪除任何人的推文，刪除成功顯示刪除成功，刪除失敗顯示刪除失敗原因

**[增加]**
`api/base.js` 新增 getData function 處理回傳的資料結構