### PR TITLE
Feature/api edit account

### DIFF
--- a/src/api/editAccount.js
+++ b/src/api/editAccount.js
@@ -1,0 +1,21 @@
+import { axiosInstance, baseUrl } from "./base"
+
+
+export const editAccount = async(payload) => {
+
+  try{
+    const {account,name,email,password,checkPassword} = 
+    payload;
+    const response = await axiosInstance.put(`${baseUrl}/api/users/14/account`, {
+      account,
+      name,
+      email,
+      password,
+      checkPassword
+    });
+    console.log(response)
+    return response.status
+  } catch(error){
+    console.error('[Edit Account failed]: ', error)
+  }
+}

--- a/src/api/editAccount.js
+++ b/src/api/editAccount.js
@@ -1,21 +1,20 @@
-import { axiosInstance, baseUrl } from "./base"
-
+import { axiosInstance, baseUrl} from "./base"
 
 export const editAccount = async(payload) => {
-
-  try{
-    const {account,name,email,password,checkPassword} = 
+  const { userId, account, name, email, password, checkPassword } = 
     payload;
-    const response = await axiosInstance.put(`${baseUrl}/api/users/14/account`, {
+
+  try {
+    const response = await axiosInstance.put(`${baseUrl}/api/users/${userId}/account`, {
       account,
       name,
       email,
       password,
       checkPassword
     });
-    console.log(response)
-    return response.status
+    return response.data
   } catch(error){
     console.error('[Edit Account failed]: ', error)
+    return error.response.data
   }
-}
+} 

--- a/src/pages/SettingPage.jsx
+++ b/src/pages/SettingPage.jsx
@@ -1,6 +1,8 @@
 import styled from "styled-components"
 import { Input, Button, Header } from "components"
 import { useState } from "react"
+import { editAccount} from "api/editAccount"
+import Swal from "sweetalert2"
 
 
 const SettingFormContainer = styled.div`
@@ -35,6 +37,52 @@ const SettingPage = () => {
     const [password, setPassword] = useState('')
     const [checkPassword, setCheckPassword] = useState('')
     
+    // function handleSubmit(e) {
+    //     e.preventDefault()
+    // }
+    
+    // 按下儲存按鈕
+    async function handleSave () {
+
+      //檢查輸入框是否未填寫
+      if (account.length === 0 || name.length === 0 || email.length ===0 || password.length === 0 ||checkPassword ===0){
+        return;
+      }
+
+      // 呼叫 SetAccount API
+      const response = await editAccount ({
+      account,
+      name,
+      email,
+      password,
+      checkPassword
+      })
+      
+      // 檢查是否儲存成功
+      const isSaved = (response.status === 'success') ? true : false
+       if (isSaved) {
+        Swal.fire({
+                title: '登入成功!',
+                icon: 'success',
+                showConfirmButton: false,
+                timer: 3000,
+                position: 'top',
+            });
+       } else {
+        Swal.fire({
+                title: '登入失敗!',
+                icon: 'error',
+                html: `<p>${response.message}</p>`,
+                showConfirmButton: false,
+                timer: 3000,
+                position: 'top',
+            });
+       }
+      }
+
+
+
+
     return (        
             <SettingFormContainer>           
                 <Header text='帳戶設定'/>
@@ -88,6 +136,7 @@ const SettingPage = () => {
                     type='submit'
                     text='儲存'
                     size = 'large'
+                    onClick = {handleSave}
                 />
               </StyledButtonWrapper>
               </SettingForm>

--- a/src/pages/SettingPage.jsx
+++ b/src/pages/SettingPage.jsx
@@ -2,6 +2,7 @@ import styled from "styled-components"
 import { Input, Button, Header } from "components"
 import { useState } from "react"
 import { editAccount} from "api/editAccount"
+import { useAuth } from "contexts/AuthContext"
 import Swal from "sweetalert2"
 
 
@@ -24,7 +25,6 @@ const StyledButtonWrapper = styled.div`
   }
 `
 
-
 /**
  * [前台] 設定頁
  * @returns 
@@ -36,21 +36,20 @@ const SettingPage = () => {
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
     const [checkPassword, setCheckPassword] = useState('')
+    const {currentRegistrant} = useAuth()
+
     
-    // function handleSubmit(e) {
-    //     e.preventDefault()
-    // }
+    // 防止表單提交
+    function handleSubmit(e) {
+    e.preventDefault()
+    }
     
     // 按下儲存按鈕
     async function handleSave () {
 
-      //檢查輸入框是否未填寫
-      if (account.length === 0 || name.length === 0 || email.length ===0 || password.length === 0 ||checkPassword ===0){
-        return;
-      }
-
-      // 呼叫 SetAccount API
-      const response = await editAccount ({
+    // 呼叫 editAccount API
+    const response = await editAccount ({
+      userId: currentRegistrant.id,
       account,
       name,
       email,
@@ -58,41 +57,45 @@ const SettingPage = () => {
       checkPassword
       })
       
-      // 檢查是否儲存成功
+    // 檢查儲存是否成功
       const isSaved = (response.status === 'success') ? true : false
        if (isSaved) {
         Swal.fire({
-                title: '登入成功!',
+                title: '儲存成功!',
                 icon: 'success',
                 showConfirmButton: false,
+                html: `<p>${response.message}</p>`,
                 timer: 3000,
                 position: 'top',
             });
        } else {
+        //  設定錯誤提示字串
+         let errorMsg = ''
+         for (let error of response.errors) {
+          errorMsg += error + '<br/>'
+         }
+
         Swal.fire({
-                title: '登入失敗!',
+                title: '儲存失敗!',
                 icon: 'error',
-                html: `<p>${response.message}</p>`,
                 showConfirmButton: false,
+                html: `<p>${errorMsg}</p>`,
                 timer: 3000,
                 position: 'top',
             });
        }
       }
 
-
-
-
     return (        
             <SettingFormContainer>           
                 <Header text='帳戶設定'/>
-                <SettingForm>
+                <SettingForm onSubmit ={handleSubmit}>
                 <Input
                     label='帳號'
                     name='account'
                     placeholder='請輸入帳號'
                     value={account}
-                    required={true}
+                    required= {true}
                     onChange={(e) => { setAccount(e.target.value) }}
                 />
                  <Input


### PR DESCRIPTION
1. 新增 api editAccount 及調整 SettingPage 頁面。
2. 登入後至左邊 SideBar 設定頁可設定帳戶資料。
3. 設定頁符合以下條件：
-     設定成功顯示：帳戶設定成功；
-     設定失敗依照錯誤欄位題示以下：
        "所有欄位皆必填",
        "密碼長度不能超過20字元",
        "密碼與確認密碼不相符",
        "請輸入有效的 email 格式",
        "帳號已重複註冊！",
        "Email已重複註冊！"
4. 設定成功可登出再以新帳號密碼登入。

